### PR TITLE
Added build script and designated Roxygen

### DIFF
--- a/births.Rproj
+++ b/births.Rproj
@@ -18,3 +18,5 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageBuildArgs: --no-save < build.R
+PackageRoxygenize: rd,collate,namespace

--- a/births.Rproj
+++ b/births.Rproj
@@ -18,5 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
-PackageBuildArgs: --no-save < build.R
 PackageRoxygenize: rd,collate,namespace

--- a/build.R
+++ b/build.R
@@ -1,0 +1,4 @@
+# Loop through all Rmd files in studies folder and render them
+for(rmd in tools::list_files_with_exts('studies', ext='Rmd', all.files = TRUE)) {
+    rmarkdown::render(rmd)
+}


### PR DESCRIPTION
The `build.R` script will iterate through the studies folder and
render all of the Rmd files that are contained inside.

Also modified the .Rpoj to use Roxygen as the default documentation
builder, which is now triggered on build in R-Studio.